### PR TITLE
Fix CSS path for coloring every second row

### DIFF
--- a/lib/static/style/auto/orcid_support_advance.css
+++ b/lib/static/style/auto/orcid_support_advance.css
@@ -118,6 +118,6 @@ table.export_orcid_records tr td{
     padding: 5px 10px;
 }
 
-table.export_orcid_records tr:nth-child(odd){
+table.export_orcid_records > tbody > tr:nth-child(odd){
     background-color:#eee;
 }


### PR DESCRIPTION
The problem is that inside this row `tr` there is another table with just one row some columns. Thus, the previous CSS path matched also this inner `tr` which is always the first and therefore odd. This means, that currently every row was colored grey (minus some more white on the border). By using the direct child operator `>` we can avoid that.