### PR TITLE
Subclass reports

### DIFF
--- a/cfg/cfg.d/z_orcid_support_advance.pl
+++ b/cfg/cfg.d/z_orcid_support_advance.pl
@@ -28,9 +28,9 @@ $c->{"plugins"}->{"Event::CheckOrcidName"}->{"params"}->{"disable"} = 0;
 $c->{"plugins"}->{"Event::UpdateCreatorOrcid"}->{"params"}->{"disable"} = 0;
 
 ####Enable Report Plugins###
-$c->{plugins}{"Screen::Report::Orcid::CheckName"}{params}{disable} = 0;
-$c->{plugin_alias_map}->{"Screen::Report::Orcid::UserOrcid"} = "Screen::Report::Orcid::UserPermsOrcid";
-$c->{plugin_alias_map}->{"Screen::Report::Orcid::UserPermsOrcid"} = undef;
+$c->{plugins}{"Screen::Report::User::Orcid::CheckName"}{params}{disable} = 0;
+$c->{plugin_alias_map}->{"Screen::Report::User::Orcid::UserOrcid"} = "Screen::Report::User::Orcid::UserPermsOrcid";
+$c->{plugin_alias_map}->{"Screen::Report::User::Orcid::UserPermsOrcid"} = undef;
 
 ###Override DOI Import plugin###
 $c->{plugin_alias_map}->{"Import::DOI"} = "Import::OrcidDOI";

--- a/lib/lang/de/phrases/z_orcid_support_advance.xml
+++ b/lib/lang/de/phrases/z_orcid_support_advance.xml
@@ -92,6 +92,7 @@ Nach Erteilung dieser Genehmigung wird <epc:phrase ref="archive_name" /> auch ve
 <epp:phrase id="report/userperms:/authenticate">Ihre ORCID abrufen ist gewährt</epp:phrase>
 <epp:phrase id="report/userperms:/activities/update">Erstellen und aktualisieren von Details Ihrer Forschungsaktivitäten ist gewährt</epp:phrase>
 <epp:phrase id="report/userperms:/read-limited">Abrufen von Details aus Ihrem ORCID-Profil, die nur für vertrauenswürdige Parteien bestimmt sind, ist gewährt</epp:phrase>
+<epp:phrase id="report/userperms:token_expiry">ORCID Token Ablaufdatum: <epc:pin name="token" /></epp:phrase>
 
 <!-- ORCID Field -->
 <epp:phrase id="user_fieldhelp_orcid">Benutzen Sie den 'Mit ORCID verbinden' Link um Ihre ORCID festzulegen.</epp:phrase>

--- a/lib/lang/de/phrases/z_orcid_support_advance.xml
+++ b/lib/lang/de/phrases/z_orcid_support_advance.xml
@@ -83,7 +83,7 @@ Nach Erteilung dieser Genehmigung wird <epc:phrase ref="archive_name" /> auch ve
 <epp:phrase id="Plugin/Screen/ManageOrcid:confirm_erase_dialog">Sind Sie sicher?\nAre you sure?\nEinmal entfernt, können wir den ORCID-Eintrag des Nutzers/der Nutzerin nicht mehr pflegen, bis er/sie sich wieder mit ORCID authentifiziert hat.</epp:phrase>
 
 <!-- Name Report -->
-<epp:phrase id="Plugin/Screen/Report/Orcid/CheckName:title">orcid.org Nichtübereinstimmung von Namen</epp:phrase>
+<epp:phrase id="Plugin/Screen/Report/User/Orcid/CheckName:title">orcid.org Nichtübereinstimmung von Namen</epp:phrase>
 <epp:phrase id="given_name_mismatch">Name stimmt nicht mit dem Vornamen auf orcid.org überein: <epc:pin name="given" /></epp:phrase>
 <epp:phrase id="family_name_mismatch">Name stimmt nicht mit dem Nachnamen auf orcid.org überein: <epc:pin name="family" /></epp:phrase>
 <epp:phrase id="exportfields:check_name">Nutzer</epp:phrase>

--- a/lib/lang/en/phrases/z_orcid_support_advance.xml
+++ b/lib/lang/en/phrases/z_orcid_support_advance.xml
@@ -92,6 +92,7 @@ Upon allowing this permission, <epc:phrase ref="archive_name" /> will also attem
 <epp:phrase id="report/userperms:/authenticate">Retrieve your ORCID id granted</epp:phrase>
 <epp:phrase id="report/userperms:/activities/update">Create and update details of your research activities granted</epp:phrase>
 <epp:phrase id="report/userperms:/read-limited">Retrieve details from your ORCID profile restricted to trusted parties only granted</epp:phrase>
+<epp:phrase id="report/userperms:token_expiry">ORCID token expiry date: <epc:pin name="token" /></epp:phrase>
 
 <!-- ORCID Field -->
 <epp:phrase id="user_fieldhelp_orcid">Use 'Connect to ORCID' link to set your ORCID.</epp:phrase>

--- a/lib/lang/en/phrases/z_orcid_support_advance.xml
+++ b/lib/lang/en/phrases/z_orcid_support_advance.xml
@@ -83,7 +83,7 @@ Upon allowing this permission, <epc:phrase ref="archive_name" /> will also attem
 <epp:phrase id="Plugin/Screen/ManageOrcid:confirm_erase_dialog">Are you sure?\nOnce removed we will not be able to maintain the user&apos;s ORCID record until they reauthenticate with ORCID</epp:phrase>
 
 <!-- Name Report -->
-<epp:phrase id="Plugin/Screen/Report/Orcid/CheckName:title">orcid.org Name Mismatch</epp:phrase>
+<epp:phrase id="Plugin/Screen/Report/User/Orcid/CheckName:title">orcid.org Name Mismatch</epp:phrase>
 <epp:phrase id="given_name_mismatch">Name does not match given name on orcid.org: <epc:pin name="given" /></epp:phrase>
 <epp:phrase id="family_name_mismatch">Name does not match family name on orcid.org: <epc:pin name="family" /></epp:phrase>
 <epp:phrase id="exportfields:check_name">User</epp:phrase>

--- a/lib/plugins/EPrints/Plugin/Screen/Report/User/Orcid/CheckName.pm
+++ b/lib/plugins/EPrints/Plugin/Screen/Report/User/Orcid/CheckName.pm
@@ -1,7 +1,7 @@
-package EPrints::Plugin::Screen::Report::Orcid::CheckName;
+package EPrints::Plugin::Screen::Report::User::Orcid::CheckName;
 
-use EPrints::Plugin::Screen::Report::Orcid;
-our @ISA = ( 'EPrints::Plugin::Screen::Report::Orcid' );
+use EPrints::Plugin::Screen::Report::User::Orcid;
+our @ISA = ( 'EPrints::Plugin::Screen::Report::User::Orcid' );
 
 use strict;
 
@@ -11,25 +11,10 @@ sub new
 
         my $self = $class->SUPER::new( %params );
 
-        $self->{datasetid} = 'user';
-        $self->{custom_order} = '-name';
         $self->{report} = 'orcid-user';
 
-	$self->{show_compliance} = 0;
-
-	$self->{labels} = {
-                outputs => "users"
-        };
-
         $self->{exportfields} = {
-                check_name => [ qw(
-                        userid
-                        username
-                        email
-                        name
-                        orcid
-			orcid_name
-                )],
+                check_name => [ qw( orcid_name )],
         };
 
         return $self;
@@ -115,7 +100,3 @@ sub validate_dataobj
 
         return @problems;
 }
-
-
-
-

--- a/lib/plugins/EPrints/Plugin/Screen/Report/User/Orcid/UserPermsOrcid.pm
+++ b/lib/plugins/EPrints/Plugin/Screen/Report/User/Orcid/UserPermsOrcid.pm
@@ -1,7 +1,7 @@
-package EPrints::Plugin::Screen::Report::Orcid::UserPermsOrcid;
+package EPrints::Plugin::Screen::Report::User::Orcid::UserPermsOrcid;
 
-use EPrints::Plugin::Screen::Report::Orcid::UserOrcid;
-our @ISA = ( 'EPrints::Plugin::Screen::Report::Orcid::UserOrcid' );
+use EPrints::Plugin::Screen::Report::User::Orcid::UserOrcid;
+our @ISA = ( 'EPrints::Plugin::Screen::Report::User::Orcid::UserOrcid' );
 
 use strict;
 
@@ -30,5 +30,3 @@ sub bullet_points
 
         return @bullets;
 }
-
-                       

--- a/lib/plugins/EPrints/Plugin/Screen/Report/User/Orcid/UserPermsOrcid.pm
+++ b/lib/plugins/EPrints/Plugin/Screen/Report/User/Orcid/UserPermsOrcid.pm
@@ -28,5 +28,9 @@ sub bullet_points
 		}
 	}
 
+    if( $user->is_set( "orcid_token_expires" ) ){
+        push @bullets, EPrints::XML::to_string( $repo->html_phrase( "report/userperms:token_expiry", token => $repo->xml->create_text_node( $user->get_value( "orcid_token_expires" ) ) ) );
+    }
+
         return @bullets;
 }


### PR DESCRIPTION
Kind of fixes #35 since now sort fields and group fields are inherited from parent classes and thereby from archive config, which renders the orcid reports more coherent with the rest of the archive. Custom orders and groupings can easily be added as usual. (See also [this PR](https://github.com/eprints/orcid_support/pull/28).)
(Tagging @wfyson)