### PR TITLE
fix for a Workflow::view error which happens when the dataset is 'eprint' and not 'user'

### DIFF
--- a/lib/plugins/EPrints/Plugin/Screen/ExportToOrcid.pm
+++ b/lib/plugins/EPrints/Plugin/Screen/ExportToOrcid.pm
@@ -55,7 +55,8 @@ sub can_be_viewed{
                 return 1;
         }
 
-        if( $screenid eq "Workflow::View") #user profile screen
+        my $dataset = $self->{repository}->param( "dataset" );
+        if( $screenid eq "Workflow::View" && $dataset eq 'user') #user profile screen
         {
                 my $userid = $self->{repository}->param( "dataobj" );
                 if( defined $userid )

--- a/lib/plugins/EPrints/Plugin/Screen/ImportFromOrcid.pm
+++ b/lib/plugins/EPrints/Plugin/Screen/ImportFromOrcid.pm
@@ -54,7 +54,8 @@ sub can_be_viewed
 		return 1;
 	}
 
-	if( $screenid eq "Workflow::View") #user profile screen
+    my $dataset = $self->{repository}->param( "dataset" );
+    if( $screenid eq "Workflow::View" && $dataset eq 'user') #user profile screen
 	{
 		my $userid = $self->{repository}->param( "dataobj" );
 		if( defined $userid )

--- a/orcid_support_advance.epmi
+++ b/orcid_support_advance.epmi
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<epm xmlns='http://eprints.org/ep2/data/2.0' id='http://template.ulcc.ac.uk/id/epm/orcid_support_advance'>
+<epm xmlns='http://eprints.org/ep2/data/2.0' id='http://localhost:8080/id/epm/orcid_support_advance'>
   <epmid>orcid_support_advance</epmid>
   <uri>http://template.ulcc.ac.uk/id/epm/orcid_support_advance</uri>
   <documents>
@@ -7,67 +7,59 @@
       <files>
         <file>
           <datasetid>document</datasetid>
-          <filename>lang/en/static/orcid_support_advance.xpage</filename>
-          <mime_type>application/xml</mime_type>
-          <hash>bd76ca83683e8a5c4e4cfe0287bc7d57</hash>
+          <filename>epm/orcid_support_advance/cfg/cfg.d/z_orcid_support_advance.pl</filename>
+          <mime_type>text/plain</mime_type>
+          <hash>21a116d3e75af8a0599d03e01f7574f2</hash>
           <hash_type>MD5</hash_type>
-          <filesize>4763</filesize>
+          <filesize>14951</filesize>
         </file>
         <file>
           <datasetid>document</datasetid>
-          <filename>lang/en/phrases/z_orcid_support_advance.xml</filename>
-          <mime_type>application/xml</mime_type>
-          <hash>4754204548878dd875e6d6c91cba78c5</hash>
+          <filename>epm/orcid_support_advance/cfg/cfg.d/z_orcid_support_advance_rdf_triples.pl</filename>
+          <mime_type>text/plain</mime_type>
+          <hash>b4fc3887de5b4580ec9a0ff0ea62ec04</hash>
           <hash_type>MD5</hash_type>
-          <filesize>12800</filesize>
+          <filesize>4641</filesize>
         </file>
         <file>
           <datasetid>document</datasetid>
-          <filename>lang/de/static/orcid_support_advance.xpage</filename>
-          <mime_type>application/xml</mime_type>
-          <hash>0effca1069b3b2ca0c755460e2bf8608</hash>
+          <filename>epm/orcid_support_advance/cgi/orcid/authenticate</filename>
+          <mime_type>text/plain</mime_type>
+          <hash>ecebd6f71518946bdf7cf9caa9af7355</hash>
           <hash_type>MD5</hash_type>
-          <filesize>5413</filesize>
+          <filesize>3782</filesize>
         </file>
         <file>
           <datasetid>document</datasetid>
           <filename>lang/de/phrases/z_orcid_support_advance.xml</filename>
           <mime_type>application/xml</mime_type>
-          <hash>833694402ee3684134ad5f0328dca216</hash>
+          <hash>1de7cfc0efa612d7695911ec7b882ade</hash>
           <hash_type>MD5</hash_type>
-          <filesize>13898</filesize>
+          <filesize>13790</filesize>
         </file>
         <file>
           <datasetid>document</datasetid>
-          <filename>static/images/orcid_24x24.png</filename>
-          <mime_type>image/png</mime_type>
-          <hash>3cbd9f47c59c6e11cc98d66d147c2b5f</hash>
+          <filename>lang/de/static/orcid_support_advance.xpage</filename>
+          <mime_type>application/xml</mime_type>
+          <hash>3dfd3803fc2776aa174435a0e8ff248a</hash>
           <hash_type>MD5</hash_type>
-          <filesize>1399</filesize>
+          <filesize>5376</filesize>
         </file>
         <file>
           <datasetid>document</datasetid>
-          <filename>static/images/orcid_16x16.png</filename>
-          <mime_type>image/png</mime_type>
-          <hash>2dddb203aa38ec94870d3ef2b43921c4</hash>
+          <filename>lang/en/phrases/z_orcid_support_advance.xml</filename>
+          <mime_type>application/xml</mime_type>
+          <hash>ea60df8f2a7607be9288bcf3239e07db</hash>
           <hash_type>MD5</hash_type>
-          <filesize>1261</filesize>
+          <filesize>12692</filesize>
         </file>
         <file>
           <datasetid>document</datasetid>
-          <filename>static/images/epm/orcid_support_advance.png</filename>
-          <mime_type>image/png</mime_type>
-          <hash>41881d439c830058408156fa48c4a260</hash>
+          <filename>lang/en/static/orcid_support_advance.xpage</filename>
+          <mime_type>application/xml</mime_type>
+          <hash>3ef27a8d89faa01099f9aed3846e7808</hash>
           <hash_type>MD5</hash_type>
-          <filesize>12579</filesize>
-        </file>
-        <file>
-          <datasetid>document</datasetid>
-          <filename>static/style/auto/orcid_support_advance.css</filename>
-          <mime_type>text/x-c</mime_type>
-          <hash>5252258ab888c2f7d36f62193270c299</hash>
-          <hash_type>MD5</hash_type>
-          <filesize>2399</filesize>
+          <filesize>4725</filesize>
         </file>
         <file>
           <datasetid>document</datasetid>
@@ -79,19 +71,19 @@
         </file>
         <file>
           <datasetid>document</datasetid>
-          <filename>plugins/EPrints/Plugin/Event/OrcidSync.pm</filename>
-          <mime_type>text/plain</mime_type>
-          <hash>ce19d9bba8fecb9c7d6719c7c32dd768</hash>
-          <hash_type>MD5</hash_type>
-          <filesize>3455</filesize>
-        </file>
-        <file>
-          <datasetid>document</datasetid>
           <filename>plugins/EPrints/Plugin/Event/CheckOrcidName.pm</filename>
           <mime_type>text/plain</mime_type>
           <hash>fae137f6ee5df4db1ff0e2c15c387bf2</hash>
           <hash_type>MD5</hash_type>
           <filesize>1913</filesize>
+        </file>
+        <file>
+          <datasetid>document</datasetid>
+          <filename>plugins/EPrints/Plugin/Event/OrcidSync.pm</filename>
+          <mime_type>text/plain</mime_type>
+          <hash>ce19d9bba8fecb9c7d6719c7c32dd768</hash>
+          <hash_type>MD5</hash_type>
+          <filesize>3455</filesize>
         </file>
         <file>
           <datasetid>document</datasetid>
@@ -111,14 +103,6 @@
         </file>
         <file>
           <datasetid>document</datasetid>
-          <filename>plugins/EPrints/Plugin/Screen/ManageOrcid.pm</filename>
-          <mime_type>text/plain</mime_type>
-          <hash>1113243ca14a5eeb7d137ccf18a1512c</hash>
-          <hash_type>MD5</hash_type>
-          <filesize>9600</filesize>
-        </file>
-        <file>
-          <datasetid>document</datasetid>
           <filename>plugins/EPrints/Plugin/Screen/AuthenticateOrcid.pm</filename>
           <mime_type>text/plain</mime_type>
           <hash>fa18d8158c1c67db9e222f2afba6e632</hash>
@@ -127,35 +111,27 @@
         </file>
         <file>
           <datasetid>document</datasetid>
-          <filename>plugins/EPrints/Plugin/Screen/ExportToOrcid.pm</filename>
+          <filename>plugins/EPrints/Plugin/Screen/ManageOrcid.pm</filename>
           <mime_type>text/plain</mime_type>
-          <hash>787bc9be84bf79f691f041056f1dcdfd</hash>
+          <hash>1113243ca14a5eeb7d137ccf18a1512c</hash>
           <hash_type>MD5</hash_type>
-          <filesize>30628</filesize>
+          <filesize>9600</filesize>
         </file>
         <file>
           <datasetid>document</datasetid>
           <filename>plugins/EPrints/Plugin/Screen/ImportFromOrcid.pm</filename>
-          <mime_type>text/x-java</mime_type>
-          <hash>4ac5c97538e1b6ba5e6d1deda88475b2</hash>
+          <mime_type>text/plain</mime_type>
+          <hash>b123ad4eacce0fc080f3895921b94d20</hash>
           <hash_type>MD5</hash_type>
-          <filesize>28641</filesize>
+          <filesize>28725</filesize>
         </file>
         <file>
           <datasetid>document</datasetid>
-          <filename>plugins/EPrints/Plugin/Screen/Report/Orcid/UserPermsOrcid.pm</filename>
+          <filename>plugins/EPrints/Plugin/Screen/ExportToOrcid.pm</filename>
           <mime_type>text/plain</mime_type>
-          <hash>14c67d4746200742fa97be441705f28e</hash>
+          <hash>78de544a996153b5bc1794060dd1263a</hash>
           <hash_type>MD5</hash_type>
-          <filesize>992</filesize>
-        </file>
-        <file>
-          <datasetid>document</datasetid>
-          <filename>plugins/EPrints/Plugin/Screen/Report/Orcid/CheckName.pm</filename>
-          <mime_type>text/plain</mime_type>
-          <hash>df7d13b6473921951794a19f0cea4717</hash>
-          <hash_type>MD5</hash_type>
-          <filesize>2993</filesize>
+          <filesize>30713</filesize>
         </file>
         <file>
           <datasetid>document</datasetid>
@@ -167,32 +143,64 @@
         </file>
         <file>
           <datasetid>document</datasetid>
-          <filename>epm/orcid_support_advance/cgi/orcid/authenticate</filename>
+          <filename>plugins/EPrints/Plugin/Screen/Report/Orcid/CheckName.pm</filename>
           <mime_type>text/plain</mime_type>
-          <hash>ecebd6f71518946bdf7cf9caa9af7355</hash>
+          <hash>df7d13b6473921951794a19f0cea4717</hash>
           <hash_type>MD5</hash_type>
-          <filesize>3782</filesize>
+          <filesize>2993</filesize>
         </file>
         <file>
           <datasetid>document</datasetid>
-          <filename>epm/orcid_support_advance/cfg/cfg.d/z_orcid_support_advance.pl</filename>
+          <filename>plugins/EPrints/Plugin/Screen/Report/Orcid/UserPermsOrcid.pm</filename>
           <mime_type>text/plain</mime_type>
-          <hash>77a254318e004572152c1888d24c1f5e</hash>
+          <hash>14c67d4746200742fa97be441705f28e</hash>
           <hash_type>MD5</hash_type>
-          <filesize>14887</filesize>
+          <filesize>992</filesize>
         </file>
         <file>
           <datasetid>document</datasetid>
-          <filename>epm/orcid_support_advance/cfg/cfg.d/z_orcid_support_advance_rdf_triples.pl</filename>
-          <mime_type>text/plain</mime_type>
-          <hash>b4fc3887de5b4580ec9a0ff0ea62ec04</hash>
+          <filename>static/images/orcid_16x16.png</filename>
+          <mime_type>image/png</mime_type>
+          <hash>2dddb203aa38ec94870d3ef2b43921c4</hash>
           <hash_type>MD5</hash_type>
-          <filesize>4641</filesize>
+          <filesize>1261</filesize>
+        </file>
+        <file>
+          <datasetid>document</datasetid>
+          <filename>static/images/orcid_24x24.png</filename>
+          <mime_type>image/png</mime_type>
+          <hash>3cbd9f47c59c6e11cc98d66d147c2b5f</hash>
+          <hash_type>MD5</hash_type>
+          <filesize>1399</filesize>
+        </file>
+        <file>
+          <datasetid>document</datasetid>
+          <filename>static/images/epm/orcid_support_advance.png</filename>
+          <mime_type>image/png</mime_type>
+          <hash>41881d439c830058408156fa48c4a260</hash>
+          <hash_type>MD5</hash_type>
+          <filesize>12579</filesize>
+        </file>
+        <file>
+          <datasetid>document</datasetid>
+          <filename>static/javascript/auto/90_orcid_support_advance.js</filename>
+          <mime_type>text/plain</mime_type>
+          <hash>0382009769f12d9400b22fd35590ea75</hash>
+          <hash_type>MD5</hash_type>
+          <filesize>695</filesize>
+        </file>
+        <file>
+          <datasetid>document</datasetid>
+          <filename>static/style/auto/orcid_support_advance.css</filename>
+          <mime_type>text/x-asm</mime_type>
+          <hash>20624fe977a9d4dcde7518a15da33b90</hash>
+          <hash_type>MD5</hash_type>
+          <filesize>2466</filesize>
         </file>
       </files>
-      <mime_type>text/plain</mime_type>
+      <mime_type>text/x-asm</mime_type>
       <format>text</format>
-      <main>epm/orcid_support_advance/cfg/cfg.d/z_orcid_support_advance_rdf_triples.pl</main>
+      <main>static/style/auto/orcid_support_advance.css</main>
       <content>install</content>
     </document>
     <document>
@@ -235,7 +243,7 @@
       </name>
     </item>
   </creators>
-  <datestamp>2018-12-23 02:13:22</datestamp>
+  <datestamp>2019-08-28 13:41:52</datestamp>
   <title>ORCID Support Advance</title>
   <description>ORCID Support Advance offers enhanced functionality, designed to build on top of the features already present in ORCID Support. 
 


### PR DESCRIPTION
Hello,

This small change fixes an issue that occurs when an Eprint is accessed from the "manage records" screen. The issue is caused by the fact that the code assumed that the value of the 'dataset' parameter was 'user', while it could be also 'eprint'.

