### PR TITLE
Fix for internal server error when updating event queue task

### DIFF
--- a/lib/plugins/EPrints/Plugin/Screen/ExportToOrcid.pm
+++ b/lib/plugins/EPrints/Plugin/Screen/ExportToOrcid.pm
@@ -71,7 +71,7 @@ sub can_be_viewed{
                                 #has the subject user given permission to read their orcid.org profile?
                                 my $ds = $repo->get_dataset( "user" );
                                 my $user = $ds->dataobj( $userid );
-				if( EPrints::Utils::is_set( $user->value( "orcid" ) ) )
+				if( defined $user && EPrints::Utils::is_set( $user->value( "orcid" ) ) )
                                 {
                                 	return 1;
 				}

--- a/lib/plugins/EPrints/Plugin/Screen/ImportFromOrcid.pm
+++ b/lib/plugins/EPrints/Plugin/Screen/ImportFromOrcid.pm
@@ -70,7 +70,7 @@ sub can_be_viewed
 				#has the subject user given permission to read their orcid.org profile?
 				my $ds = $repo->get_dataset( "user" );
 				my $user = $ds->dataobj( $userid );
-				if( EPrints::Utils::is_set( $user->value( "orcid" ) ) )
+				if( defined $user && EPrints::Utils::is_set( $user->value( "orcid" ) ) )
 				{
 					return 1;
 				}


### PR DESCRIPTION
When updating an event_queue task the user lookup in the import and export plugins for ORCID Support advance are called but do not work causing an internal server error.  This makes it impossible to update the event queue task (e.g. so it runs again if it originally failed).  Before testing if the user has an orcid set, make sure the user lookup was successful by checking the user object is defined.