### PR TITLE
Revert "ejo - removed encoding"

### DIFF
--- a/lib/plugins/EPrints/ORCID/AdvanceUtils.pm
+++ b/lib/plugins/EPrints/ORCID/AdvanceUtils.pm
@@ -196,16 +196,14 @@ sub write_orcid_record
 
 	my $uri = $repo->config( "orcid_support_advance", "orcid_apiv2") . $user->value( "orcid" ) . $item;
 
-	my $content_as_json = to_json( $content );
-
 	my $req = HTTP::Request->new( $method, $uri );
         my @headers = (
                 'Content-type' => 'application/vnd.orcid+json',
                 'Authorization' => 'Bearer ' . $user->value( "orcid_access_token" ),
-		'Content-Lengh' => length( $content_as_json ),
+		'Content-Lengh' => length( encode_utf8(to_json( $content ) ) ),
 	);
 	$req->header( @headers );
-	$req->content( $content_as_json );
+	$req->content( encode_utf8(to_json( $content ) ) );
 
 	my $lwp = LWP::UserAgent->new;
 	my $response = $lwp->request( $req );


### PR DESCRIPTION
Reverts eprints/orcid_support_advance#75

This works for people who have a file encoded as utf8, not for those who do not.