### PR TITLE
EJO: Adding functionality for bespoke field mappings

### DIFF
--- a/cfg/cfg.d/z_orcid_support_advance.pl
+++ b/cfg/cfg.d/z_orcid_support_advance.pl
@@ -316,6 +316,26 @@ $c->{orcid_support_advance}->{"work_type_to_eprint"} = sub {
     return "other";
 };
 
+# Add custom field mappings here i.e. if you have bespoke eprints fields which need mapping to orcid metadata
+$c->{orcid_support_advance}->{"eprint_to_work_custom"} = sub {
+        my ( $eprint, $work ) = @_;
+
+       # EXAMPLE: Adding a doi as an external id, useful for Orcid.org detecting duplicates on profile
+       #if ( $eprint->exists_and_set( "id_number" ) && EPrints::DOI->parse($eprint->get_value( "id_number" )) )
+       #{
+       #        my $doi = $eprint->get_value( "id_number" );
+       #        push( @{$work->{"external-ids"}->{"external-id"}},
+       #                {
+       #                        "external-id-type" => "doi",
+       #                        "external-id-value" => $doi,
+       #                        "external-id-url" => "https://doi.org/$doi",
+       #                        "external-id-relationship" => "SELF",
+       #                }
+       #        );
+       #}
+
+        return $work;
+}
 
 # contributor types mapping from EPrints to ORCID - used in Screen::ExportToOrcid to add contributor details to orcid-works and when importing works to eprints
 $c->{orcid_support_advance}->{contributor_map} = {

--- a/lib/plugins/EPrints/ORCID/Exporter.pm
+++ b/lib/plugins/EPrints/ORCID/Exporter.pm
@@ -366,6 +366,9 @@ sub _eprint_to_orcid_work
     }
     $work->{"contributors"}->{"contributor"} = $contributors;
 
+    # Custom repo to orcid attribute mappings
+    $work = &{$repo->config( "orcid_support_advance", "eprint_to_work_custom" )}( $eprint, $work );
+
     return $work;
 }
 


### PR DESCRIPTION
The changes made in this commit are not breaking.

Currently the only option to add bespoke mappings are for item types. There could be any amount of bespoke fields or custom mappings needed depending on how an EPrints repo has been setup and customized. This can be solved by calling out to a config level function which can manipulate the current mapping or write their own from scratch, allowing for better integration.

DOI usage should probably be standard, as this is one of the ways orcid determines duplication.