### PR TITLE
WR: Fix putcode heading not being hidden when it should be

### DIFF
--- a/lib/static/javascript/auto/90_orcid_support_advance.js
+++ b/lib/static/javascript/auto/90_orcid_support_advance.js
@@ -2,7 +2,7 @@
 // Hide putcode field in workflow
 
 function hidePutcode() {
-    var ths = document.querySelectorAll('[id*="_creators_th_"], [id*="_editors_th_"]');
+    var ths = document.querySelectorAll('[id*="_creators_putcode_label"], [id*="_editors_putcode_label"]');
     var inputs = document.querySelectorAll('[class*="ep_eprint_creators_putcode"], [class*="ep_eprint_editors_putcode"]');
     var tds = [];
 


### PR DESCRIPTION
This fixes the hidePutcode function to correctly hide the table heading for putcodes in the workflow - the ID for the putcode heading had changed and the selector was not matching it.