### PR TITLE
Fixes #92 by checking for valid-ish ORCID before looking up user

### DIFF
--- a/lib/plugins/EPrints/Plugin/Screen/ImportFromOrcid.pm
+++ b/lib/plugins/EPrints/Plugin/Screen/ImportFromOrcid.pm
@@ -834,8 +834,11 @@ sub import_via_orcid
 			if( defined( $contributor->{"contributor-orcid"} ) )
 			{
 				#search for user with orcid and add username to eprint contributor if found
-				$orcid = $contributor->{"contributor-orcid"}->{"path"} if $contributor->{"contributor-orcid"}->{"path"} ne "null";
-				$c_user = EPrints::ORCID::Utils::user_with_orcid( $repo, $orcid );
+				if ( my $normalised_orcid = EPrints::ORCID::Utils::get_normalised_orcid( $contributor->{"contributor-orcid"}->{"path"} ) )
+				{
+					$orcid = $normalised_orcid;
+					$c_user = EPrints::ORCID::Utils::user_with_orcid( $repo, $orcid );
+				}
 
                 		# Save putcode if this contributor is the importing user
                 		if( $users_orcid eq $orcid )


### PR DESCRIPTION
To fix #92 check that an ORCID is set and it format looks valid-ish it should avoid the first user with and empty orcid field value (or possibly even just the first user) being retrieved and then their email being set as creators_id (or editors_id, contributors_id, etc.).