### PR TITLE
Fixed #91 by adding colon. Also normalises DOI before setting.

### DIFF
--- a/lib/plugins/EPrints/Plugin/Screen/ImportFromOrcid.pm
+++ b/lib/plugins/EPrints/Plugin/Screen/ImportFromOrcid.pm
@@ -788,11 +788,11 @@ sub import_via_orcid
 			{
 				if( $repo->dataset( 'eprint' )->has_field( "doi" ) )
 				{
-					$eprint->set_value( "doi", $identifier->{"external-id-value"} );
+					$eprint->set_value( "doi", EPrints::DOI->parse( $identifier->{"external-id-value"} )->_uri_path );
 				}
 				else
 				{
-					$eprint->set_value( "id_number", "doi".$identifier->{"external-id-value"} );
+					$eprint->set_value( "id_number", "doi:" . EPrints::DOI->parse( $identifier->{"external-id-value"} )->_uri_path );
 				}
 			}
 		        elsif ( $identifier->{"external-id-type"} eq "urn" )


### PR DESCRIPTION
When ImportFromOrcid imports a work that has a DOI the `id_number` field is set to something like `doi10.1234/5678` rather than `doi:10.1234/5678`.  Also depending on how the DOI is formatted you sometimes get things like `doihttp://dx.doi.org/10.1234/5678`.  This fixes both these issues reported in #91 as well as ensure the doi field if present is consistently set to the form 10.1234/5678 rather than a URL.